### PR TITLE
Declare encoding to avoid fatal error

### DIFF
--- a/crudini
+++ b/crudini
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 # vim:fileencoding=utf8
 #
 # Copyright (C) 2013, Pádraig Brady <P@draigBrady.com>


### PR DESCRIPTION
SyntaxError: Non-ASCII character '\xc3' in file ./crudini.py on line 5, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details
