### PR TITLE
Don't duplicate DEFAULT section header

### DIFF
--- a/crudini
+++ b/crudini
@@ -171,7 +171,7 @@ def has_default_section(filename):
             fp = open(filename)
 
         for line in fp:
-            if line.rstrip() == '[%s]' % iniparse.DEFAULTSECT:
+            if line.startswith('[%s]' % iniparse.DEFAULTSECT):
                 return True
 
         return False

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -8,335 +8,364 @@ export PATH=..:$PATH
 
 test=0
 
-fail() { test=$(($test+1)); echo "Test $test FAIL"; exit 1; }
-ok() { test=$(($test+1)); echo "Test $test OK"; }
+fail() { test=$(($test+1)); echo "Test $test FAIL (line $1)"; exit 1; }
+ok() { test=$(($test+1)); echo "Test $test OK (line $1)"; }
 
 cp ../example.ini .
 
 # invalid params ----------------------------------------
 
-# 1
 :> test.ini
-crudini 2>/dev/null && fail
-crudini --met test.init 2>/dev/null && fail # bad mode
-crudini --set 2>/dev/null && fail # no file
-crudini --set test.ini  2>/dev/null && fail # no section
-crudini --get 2>/dev/null && fail # no file
-crudini --get test.ini '' 'name' 'val' 2>/dev/null && fail # value
-crudini --get --format=bad test.ini 2>/dev/null && fail # bad format
-crudini --del 2>/dev/null && fail # no file
-crudini --del test.ini 2>/dev/null && fail # no section
-crudini --del test.ini '' 'name' 'val' 2>/dev/null && fail # value
-crudini --merge 2>/dev/null && fail # no file
-crudini --merge test.ini '' 'name' 2>/dev/null && fail # param
-crudini --del test.ini '' 'name' 'val' 2>/dev/null && fail # value
-ok
+crudini 2>/dev/null && fail $LINENO
+crudini --met test.init 2>/dev/null && fail $LINENO # bad mode
+crudini --set 2>/dev/null && fail $LINENO # no file
+crudini --set test.ini  2>/dev/null && fail $LINENO # no section
+crudini --get 2>/dev/null && fail $LINENO # no file
+crudini --get test.ini '' 'name' 'val' 2>/dev/null && fail $LINENO # value
+crudini --get --format=bad test.ini 2>/dev/null && fail $LINENO # bad format
+crudini --del 2>/dev/null && fail $LINENO # no file
+crudini --del test.ini 2>/dev/null && fail $LINENO # no section
+crudini --del test.ini '' 'name' 'val' 2>/dev/null && fail $LINENO # value
+crudini --merge 2>/dev/null && fail $LINENO # no file
+crudini --merge test.ini '' 'name' 2>/dev/null && fail $LINENO # param
+crudini --del test.ini '' 'name' 'val' 2>/dev/null && fail $LINENO # value
+ok $LINENO
 
 # --set -------------------------------------------------
 
-# 2
+# ---
 :> test.ini
 crudini --set test.ini '' name val
 printf '%s\n' 'name = val' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 3
+# ---
 :> test.ini
 crudini --set test.ini DEFAULT name val
 printf '%s\n' '[DEFAULT]' 'name = val' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 4
+# ---
 # Note blank line inserted at start
 :> test.ini
 crudini --set test.ini nonDEFAULT name val
 printf '%s\n' '' '[nonDEFAULT]' 'name = val' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 5
+# ---
 printf '%s\n' 'global=val' > test.ini
 crudini --set test.ini '' global valnew
 printf '%s\n' 'global=valnew' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 6
+# ---
 printf '%s\n' 'global=val' > test.ini
 crudini --set test.ini DEFAULT global valnew
 printf '%s\n' '[DEFAULT]' 'global=valnew' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 7
+# ---
 printf '%s\n' '[DEFAULT]' 'global=val' > test.ini
 crudini --set test.ini DEFAULT global valnew
 printf '%s\n' '[DEFAULT]' 'global=valnew' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 8
+# ---
 printf '%s\n' 'global=val' '' '[nonDEFAULT]' 'name=val' > test.ini
 crudini --set test.ini '' global valnew
 printf '%s\n' 'global=valnew' '' '[nonDEFAULT]' 'name=val' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 9
+# ---
 # Add '[DEFAULT]' if explicitly specified
 printf '%s\n' 'global=val' '' '[nonDEFAULT]' 'name=val' > test.ini
 crudini --set test.ini DEFAULT global valnew
 printf '%s\n' '[DEFAULT]' 'global=valnew' '' '[nonDEFAULT]' 'name=val' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 10
+# --- 
 printf '%s\n' '[nonDEFAULT1]' 'name=val' '[nonDEFAULT2]' 'name=val' > test.ini
 crudini --set test.ini DEFAULT global val
 printf '%s\n' '[DEFAULT]' 'global = val' '[nonDEFAULT1]' 'name=val' '[nonDEFAULT2]' 'name=val' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 11
+# ---
 printf '%s\n' '[nonDEFAULT1]' 'name=val' '[nonDEFAULT2]' 'name=val' > test.ini
 crudini --set test.ini '' global val
 printf '%s\n' 'global = val' '[nonDEFAULT1]' 'name=val' '[nonDEFAULT2]' 'name=val' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 12 Ensure '[DEFAULT]' is not duplicated
+# ---
+# Ensure '[DEFAULT]' is not duplicated
 printf '%s\n' '[DEFAULT]' > test.ini
 crudini --set test.ini DEFAULT global val
 printf '%s\n' '[DEFAULT]' 'global = val' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 13 Maintain colon separation
+# ---
+# Ensure '[DEFAULT]' is not duplicated when trailing space is present
+printf '%s\n' '[DEFAULT]  ' > test.ini
+crudini --set test.ini DEFAULT global val
+printf '%s\n' '[DEFAULT]  ' 'global = val' > good.ini
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
+
+# ---
+# Ensure '[DEFAULT]' is not duplicated when a trailing comment is present
+printf '%s\n' '[DEFAULT] #comment' > test.ini
+crudini --set test.ini DEFAULT global val
+printf '%s\n' '[DEFAULT] #comment' 'global = val' > good.ini
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
+
+# ---
+# Maintain colon separation
 crudini --set example.ini section1 colon val
-grep -q '^colon:val' example.ini && ok || fail
+grep -q '^colon:val' example.ini && ok $LINENO || fail $LINENO
 
-# 14 Maintain space separation
+# ---
+# Maintain space separation
 crudini --set example.ini section1 nospace val
-grep -q '^nospace=val' example.ini && ok || fail
+grep -q '^nospace=val' example.ini && ok $LINENO || fail $LINENO
 
-# 15 value is optional
+# ---
+# value is optional
 :> test.ini
 crudini --set test.ini '' name
 printf '%s\n' 'name = ' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 16
+# ---
 # value is optional
 printf '%s\n' 'name=val' > test.ini
 crudini --set test.ini '' name
 printf '%s\n' 'name=' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 17 --existing
+# ---
+# --existing
 :> test.ini
 crudini --set test.ini '' gname val
 crudini --set --existing test.ini '' gname val2
-crudini --set --existing test.ini '' gname2 val 2>/dev/null && fail
+crudini --set --existing test.ini '' gname2 val 2>/dev/null && fail $LINENO
 crudini --set test.ini section1 name val
 crudini --set --existing test.ini section1 name val2
-crudini --set --existing test.ini section1 name2 val 2>/dev/null && fail
+crudini --set --existing test.ini section1 name2 val 2>/dev/null && fail $LINENO
 printf '%s\n' 'gname = val2' '' '' '[section1]' 'name = val2' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 18 missing
-crudini --set missing.ini '' name val 2>/dev/null && fail || ok
+# ---
+# missing
+crudini --set missing.ini '' name val 2>/dev/null && fail $LINENO || ok $LINENO
 
 # --get -------------------------------------------------
 
-# 19 basic get
-test "$(crudini --get example.ini section1 cAps)" = 'not significant' && ok || fail
+# ---
+# basic get
+test "$(crudini --get example.ini section1 cAps)" = 'not significant' && ok $LINENO || fail $LINENO
 
-# 20 get sections
+# ---
+# get sections
 crudini --get example.ini > test.ini
 printf '%s\n' DEFAULT section1 'empty section' non-sh-compat > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 21 get implicit default section
+# ---
+# get implicit default section
 crudini --get example.ini '' > test.ini
 printf '%s\n' 'global' > good.ini
-diff -u test.ini good.ini || fail
+diff -u test.ini good.ini || fail $LINENO
 crudini --format=ini --get example.ini '' > test.ini
 printf '%s\n' '[DEFAULT]' 'global = supported' > good.ini
-diff -u test.ini good.ini || fail
-ok
+diff -u test.ini good.ini || fail $LINENO
+ok $LINENO
 
-# 22 get explicit default section
+# ---
+# get explicit default section
 crudini --get example.ini DEFAULT > test.ini
 printf '%s\n' 'global' > good.ini
-diff -u test.ini good.ini || fail
+diff -u test.ini good.ini || fail $LINENO
 crudini --get --format ini example.ini DEFAULT > test.ini
 printf '%s\n' '[DEFAULT]' 'global = supported' > good.ini
-diff -u test.ini good.ini || fail
-ok
+diff -u test.ini good.ini || fail $LINENO
+ok $LINENO
 
-# 23 get section1 in ini format
+# ---
+# get section1 in ini format
 crudini --format=ini --get example.ini section1 > test.ini
-diff -u test.ini section1.ini && ok || fail
+diff -u test.ini section1.ini && ok $LINENO || fail $LINENO
 
-# 24 get section1 in sh format
+# ---
+# get section1 in sh format
 crudini --format=sh --get example.ini section1 > test.ini
-diff -u test.ini section1.sh && ok || fail
+diff -u test.ini section1.sh && ok $LINENO || fail $LINENO
 
-# 24 empty DEFAULT is not printed
+# ---
+# empty DEFAULT is not printed
 printf '%s\n' '[DEFAULT]' '#comment' '[section1]' > test.ini
-test "$(crudini --get test.ini)" = 'section1' || fail
+test "$(crudini --get test.ini)" = 'section1' || fail $LINENO
 printf '%s\n' '#comment' '[section1]' > test.ini
-test "$(crudini --get test.ini)" = 'section1' || fail
-ok
+test "$(crudini --get test.ini)" = 'section1' || fail $LINENO
+ok $LINENO
 
-# 26 missing bits
+# ---
+# missing bits
 :> test.ini
-crudini --get missing.ini 2>/dev/null && fail
-test "$(crudini --get test.ini)" = '' || fail
-crudini --get test.ini '' || fail
-crudini --get test.ini '' 'missing' 2>/dev/null && fail
-ok
+crudini --get missing.ini 2>/dev/null && fail $LINENO
+test "$(crudini --get test.ini)" = '' || fail $LINENO
+crudini --get test.ini '' || fail $LINENO
+crudini --get test.ini '' 'missing' 2>/dev/null && fail $LINENO
+ok $LINENO
 
 # --merge -----------------------------------------------
 
-# 27 XXX: An empty default section isn't merged
+# ---
+# XXX: An empty default section isn't merged
 :> test.ini
 printf '%s\n' '[DEFAULT]' '#comment' '[section1]' |
-crudini --merge test.ini || fail
+crudini --merge test.ini || fail $LINENO
 printf '%s\n' '' '[section1]' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 28
+# ---
 :> test.ini
 printf '%s\n' '[DEFAULT]' 'name=val' '[section1]' |
-crudini --merge test.ini || fail
+crudini --merge test.ini || fail $LINENO
 printf '%s\n' '[DEFAULT]' 'name = val' '' '[section1]' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 29
+# ---
 :> test.ini
 printf '%s\n' 'name=val' |
-crudini --merge test.ini || fail
+crudini --merge test.ini || fail $LINENO
 printf '%s\n' 'name = val' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 30
+# ---
 printf '%s\n' 'name=val1' > test.ini
 printf '%s\n' 'name = val2' |
-crudini --merge test.ini || fail
+crudini --merge test.ini || fail $LINENO
 printf '%s\n' 'name=val2' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 31
+# ---
 printf '%s\n' '[DEFAULT]' 'name=val1' > test.ini
 printf '%s\n' 'name=val2' |
-crudini --merge test.ini || fail
+crudini --merge test.ini || fail $LINENO
 printf '%s\n' '[DEFAULT]' 'name=val2' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 32
+# ---
 printf '%s\n' 'name = val1' > test.ini
 printf '%s\n' 'name=val2' |
-crudini --merge test.ini '' || fail
+crudini --merge test.ini '' || fail $LINENO
 printf '%s\n' 'name = val2' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 33
+# ---
 printf '%s\n' '[DEFAULT]' 'name=val1' > test.ini
 printf '%s\n' '[DEFAULT]' 'name=val2' |
-crudini --merge test.ini || fail
+crudini --merge test.ini || fail $LINENO
 printf '%s\n' '[DEFAULT]' 'name=val2' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 34
+# ---
 printf '%s\n' '[DEFAULT]' 'name=val1' > test.ini
 printf '%s\n' '[DEFAULT]' 'name=val2' |
-crudini --merge test.ini '' || fail
+crudini --merge test.ini '' || fail $LINENO
 printf '%s\n' '[DEFAULT]' 'name=val2' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 35
+# ---
 printf '%s\n' '[DEFAULT]' 'name=val1' > test.ini
 printf '%s\n' 'name=val2' |
-crudini --merge test.ini '' || fail
+crudini --merge test.ini '' || fail $LINENO
 printf '%s\n' '[DEFAULT]' 'name=val2' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 36
+# ---
 printf '%s\n' 'name=val1' > test.ini
 printf '%s\n' 'name=val2' |
-crudini --merge test.ini DEFAULT || fail
+crudini --merge test.ini DEFAULT || fail $LINENO
 printf '%s\n' '[DEFAULT]' 'name=val2' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 37
+# ---
 printf '%s\n' 'name=val1' > test.ini
 printf '%s\n' 'name=val2' |
-crudini --merge test.ini new || fail
+crudini --merge test.ini new || fail $LINENO
 printf '%s\n' 'name=val1' '' '' '[new]' 'name = val2' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 38
+# ---
 printf '%s\n' 'name=val1' > test.ini
 printf '%s\n' 'name=val2' |
-crudini --merge --existing test.ini new 2>/dev/null && fail || ok
+crudini --merge --existing test.ini new 2>/dev/null && fail $LINENO || ok $LINENO
 
-# 39
+# ---
 printf '%s\n' 'name=val1' > test.ini
 printf '%s\n' 'name2=val2' |
-crudini --merge --existing test.ini || fail
+crudini --merge --existing test.ini || fail $LINENO
 printf '%s\n' 'name=val1' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 40
+# ---
 printf '%s\n' 'name=val1' '[section1]' 'name=val2' > test.ini
 printf '%s\n' 'name=val1a' '[section1]' 'name=val2a' |
-crudini --merge --existing test.ini || fail
+crudini --merge --existing test.ini || fail $LINENO
 printf '%s\n' 'name=val1a' '[section1]' 'name=val2a' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 41 All input sections merged to a specific section
+# ---
+# All input sections merged to a specific section
 printf '%s\n' 'name=val1' '[section1]' 'name=val2' > test.ini
 printf '%s\n' 'name=val2a' '[section2]' 'name2=val' |
-crudini --merge test.ini 'section1' || fail
+crudini --merge test.ini 'section1' || fail $LINENO
 printf '%s\n' 'name=val1' '[section1]' 'name=val2a' 'name2 = val' > good.ini
-diff -u test.ini good.ini && ok || fail
+diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
 # --del -------------------------------------------------
 
 for sec in '' '[DEFAULT]'; do
-# 42 46
+# ---
   printf '%s\n' $sec 'name = val' > test.ini
-  crudini --del test.ini '' noname || fail
-  crudini --del --existing test.ini '' noname 2>/dev/null && fail
-  crudini --del test.ini '' name || fail
+  crudini --del test.ini '' noname || fail $LINENO
+  crudini --del --existing test.ini '' noname 2>/dev/null && fail $LINENO
+  crudini --del test.ini '' name || fail $LINENO
   :> good.ini
   [ "$sec" ] && printf '%s\n' $sec > good.ini
-  diff -u test.ini good.ini && ok || fail
+  diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 43 47
+# ---
   printf '%s\n' $sec 'name = val' > test.ini
-  crudini --del test.ini 'DEFAULT' noname || fail
-  crudini --del --existing test.ini 'DEFAULT' noname 2>/dev/null && fail
-  crudini --del test.ini 'DEFAULT' name || fail
+  crudini --del test.ini 'DEFAULT' noname || fail $LINENO
+  crudini --del --existing test.ini 'DEFAULT' noname 2>/dev/null && fail $LINENO
+  crudini --del test.ini 'DEFAULT' name || fail $LINENO
   :> good.ini
   [ "$sec" ] && printf '%s\n' $sec > good.ini
-  diff -u test.ini good.ini && ok || fail
+  diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 44 48
+# ---
   printf '%s\n' $sec 'name = val' > test.ini
-  crudini --del test.ini nosect || fail
-  crudini --del --existing test.ini nosect 2>/dev/null && fail
-  crudini --del test.ini '' || fail
+  crudini --del test.ini nosect || fail $LINENO
+  crudini --del --existing test.ini nosect 2>/dev/null && fail $LINENO
+  crudini --del test.ini '' || fail $LINENO
   :> good.ini
-  diff -u test.ini good.ini && ok || fail
+  diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 
-# 45 49
+# ---
   printf '%s\n' $sec 'name = val' > test.ini
-  crudini --del test.ini nosect || fail
-  crudini --del --existing test.ini nosect 2>/dev/null && fail
-  crudini --del test.ini 'DEFAULT' || fail
+  crudini --del test.ini nosect || fail $LINENO
+  crudini --del --existing test.ini nosect 2>/dev/null && fail $LINENO
+  crudini --del test.ini 'DEFAULT' || fail $LINENO
   :> good.ini
-  diff -u test.ini good.ini && ok || fail
+  diff -u test.ini good.ini && ok $LINENO || fail $LINENO
 done
 
 # --get-lines --------------------------------------------
 
-# 50
-crudini --get --format=lines example.ini section1 > test.ini || fail
-diff -u test.ini section1.lines && ok || fail
+# ---
+crudini --get --format=lines example.ini section1 > test.ini || fail $LINENO
+diff -u test.ini section1.lines && ok $LINENO || fail $LINENO
 
-# 51
-crudini --get --format=lines example.ini > test.ini || fail
-diff -u test.ini example.lines && ok || fail
+# ---
+crudini --get --format=lines example.ini > test.ini || fail $LINENO
+diff -u test.ini example.lines && ok $LINENO || fail $LINENO


### PR DESCRIPTION
If the DEFAULT section header exists but no key/value
pairs exist within the section, crudini will add a
duplicate DEFAULT section header if you use it to set
a new value in the DEFAULT section.

This patch checks for the existence of an empty DEFAULT
section and skips adding a duplicate section header.  We
need to bypass using RawConfigParser for this, as it will
not allow you to check for the existance of the DEFAULT
section.
