### PR TITLE
Fixed usage string: a value should not be specified with --del.

### DIFF
--- a/crudini
+++ b/crudini
@@ -40,13 +40,13 @@ def usage(exitval=0):
     output = sys.stderr if exitval else sys.stdout
     output.write(
       "A utility for manipulating ini files\n"
-      "\n" +
-      "Usage: " + cmd + " --set        [OPTION]... file section   [param] [value]\n" +
-      "  or:  " + cmd + " --set --list [OPTION]... file section   [param] [list value]\n" +
-      "  or:  " + cmd + " --get        [OPTION]... file [section] [param]\n" +
-      "  or:  " + cmd + " --del        [OPTION]... file section   [param]\n" +
-      "  or:  " + cmd + " --del --list [OPTION]... file section   [param] [list value]\n" +
-      "  or:  " + cmd + " --merge      [OPTION]... file [section]\n" +
+      "\n"
+      "Usage: " + cmd + " --set        [OPTION]... file section   [param] [value]\n"
+      "  or:  " + cmd + " --set --list [OPTION]... file section   [param] [list value]\n"
+      "  or:  " + cmd + " --get        [OPTION]... file [section] [param]\n"
+      "  or:  " + cmd + " --del        [OPTION]... file section   [param]\n"
+      "  or:  " + cmd + " --del --list [OPTION]... file section   [param] [list value]\n"
+      "  or:  " + cmd + " --merge      [OPTION]... file [section]\n"
       "\n"
       "Commands:\n"
       "\n"


### PR DESCRIPTION
$ cat /tmp/test.ini
[test]
a = 123

[test2]
verbose = on

$ crudini --del /tmp/test.ini test2 verbose on
A value should not be specified with --del
A utility for manipulating ini files

Usage: crudini --set [OPTION]...   config_file section   [param] [value]
  or:  crudini --get [OPTION]...   config_file [section] [param]
  or:  crudini --del [OPTION]...   config_file section   [param] [value]
  or:  crudini --merge [OPTION]... config_file [section]
...
