### PR TITLE
parse_options function. Fixed NameError: global name 'fmt' is not defined

### DIFF
--- a/crudini
+++ b/crudini
@@ -368,7 +368,7 @@ class Crudini():
             elif o in ('--format',):
                 self.fmt = a
                 if self.fmt not in ('sh','ini','lines'):
-                    error('--format not recognized: %s' % fmt)
+                    error('--format not recognized: %s' % self.fmt)
                     self.usage(1)
             elif o in ('--existing',):
                 self.update = True


### PR DESCRIPTION
Fixed error:

```
% ./crudini --get --format=ggg test.ini 
Traceback (most recent call last):
  File "./crudini", line 694, in <module>
    sys.exit(main())
  File "./crudini", line 691, in main
    return crudini.run()
  File "./crudini", line 543, in run
    self.parse_options()
  File "./crudini", line 371, in parse_options
    error('--format not recognized: %s' % fmt)
NameError: global name 'fmt' is not defined
```
