### PR TITLE
run function. Fixed NameError: global name 'param' is not defined.

### DIFF
--- a/crudini
+++ b/crudini
@@ -660,7 +660,7 @@ class Crudini():
             error('Section not found: %s' % e.section)
             sys.exit(1)
         except ConfigParser.NoOptionError:
-            error('Parameter not found: %s' % param)
+            error('Parameter not found: %s' % self.param)
             sys.exit(1)
 
         if self.mode != '--get':


### PR DESCRIPTION
If param does not exist for --get action, displayed "NameError: global name 'param' is not defined".

```
% cat test.ini
[test]
a=1

./crudini --get test.ini test n
Traceback (most recent call last):
  File "./crudini", line 694, in <module>
    sys.exit(main())
  File "./crudini", line 691, in main
    return crudini.run()
  File "./crudini", line 663, in run
    error('Parameter not found: %s' % param)
NameError: global name 'param' is not defined
```
