### PR TITLE
fix for ambiguous error

### DIFF
--- a/crudini
+++ b/crudini
@@ -88,7 +88,8 @@ class FileLock(object):
                         if e.errno == errno.EEXIST:
                             time.sleep(1)
                         else:
-                            raise
+                            raise OSError(str(e).replace(".crudini.lck",""))
+                            #raise
                     else:
                         self.locked = True
                         break
@@ -184,7 +185,8 @@ class LockedFile(FileLock):
             if create and operation == '--del' and e.errno == errno.ENOENT:
                 self.fp = StringIO('')
             else:
-                error(str(e))
+                error(str(e).replace(".crudini.lck",""))
+                #error(str(e))
                 sys.exit(1)
 
     def delete(self):

--- a/crudini
+++ b/crudini
@@ -89,7 +89,6 @@ class FileLock(object):
                             time.sleep(1)
                         else:
                             raise OSError(str(e).replace(".crudini.lck",""))
-                            #raise
                     else:
                         self.locked = True
                         break
@@ -186,7 +185,6 @@ class LockedFile(FileLock):
                 self.fp = StringIO('')
             else:
                 error(str(e).replace(".crudini.lck",""))
-                #error(str(e))
                 sys.exit(1)
 
     def delete(self):


### PR DESCRIPTION
I found the error for when crudini is given a non-existent file in a non-existent directory to be a bit vague. So I removed the added extension in order to make the actual error clearer.

Changed from: 
$ [Errno 2] No such file or directory: '/path/to/file.crudini.lck'

To:
$ [Errno 2] No such file or directory: '/path/to/file'

