### PR TITLE
Fixes tox failures

### DIFF
--- a/crudini
+++ b/crudini
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # vim:fileencoding=utf8
 #

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ from setuptools import setup
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
+
 setup(
     name="crudini",
     version="0.9",


### PR DESCRIPTION
* tox -e py27 was failing because `./crudini` is using the global
  python interpreter in the shebang (which doesn't guarantee the
  presence of iniparser dependency). This patch modifies it so it
  sources the proper python interpreter from the env.

* tox -e pep8 was failing because of a missing whiteline. This patch
  introduces it.

Note I don't have python2.6 on my system for testing, but I assume it
will behave in a manner very similar to 2.7.