### PR TITLE
handle closed stdout gracefully

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -506,3 +506,8 @@ crudini --get test.ini DEFAULT param > /dev/null && ok || fail
 
 # Test closed stdin
 (0<&- crudini --help >/dev/null) && ok || fail
+
+# Test closed stdout
+(>&- crudini --get test.ini section param value 2>/dev/null) && fail || ok
+(>&- crudini --set - section param value 2>/dev/null) && fail || ok
+(>&- crudini --set test.ini section param value) && ok || fail


### PR DESCRIPTION
Don't error when stdout is closed, but don't actually need it.
Also give a clear message when stdout is closed but we need it.

Fixes issue #82