### PR TITLE
add support for enforcing name=val format (instead of name = val)

### DIFF
--- a/EXAMPLES
+++ b/EXAMPLES
@@ -40,3 +40,9 @@ Examples:
 # compare two ini files using standard UNIX text processing
   diff <(crudini --get --format=lines file1.ini|sort) \
        <(crudini --get --format=lines file2.ini|sort)
+
+# Rewrite ini file to use name=value format rather than name = value
+  crudini --ini-options=nospace --set config_file ''
+
+# Add/Update a var, ensuring complete file in name=value format
+  crudini --ini-options=nospace --set config_file section parameter value

--- a/README
+++ b/README
@@ -12,10 +12,12 @@ Usage: crudini --set [OPTION]...   config_file section   [param] [value]
 Options:
 
   --existing[=WHAT]  For --set, --del and --merge, fail if item is missing,
-                       where WHAT is 'file', 'section', or 'param', or if
-                       not specified; all specified items.
+                       where WHAT is 'file', 'section', or 'param',
+                       or if WHAT not specified; all specified items.
   --format=FMT       For --get, select the output FMT.
-                       Formats are sh,ini,lines
+                       Formats are 'sh','ini','lines'
+  --ini-options=OPT  Set options for handling ini files.  Options are:
+                       'nospace': use format name=value not name = value
   --inplace          Lock and write files in place.
                        This is not atomic but has less restrictions
                        than the default replacement method.
@@ -68,3 +70,9 @@ Examples:
 # compare two ini files using standard UNIX text processing
   diff <(crudini --get --format=lines file1.ini|sort) \
        <(crudini --get --format=lines file2.ini|sort)
+
+# Rewrite ini file to use name=value format rather than name = value
+  crudini --ini-options=nospace --set config_file ''
+
+# Add/Update a var, ensuring complete file in name=value format
+  crudini --ini-options=nospace --set config_file section parameter value

--- a/TODO
+++ b/TODO
@@ -33,8 +33,3 @@ http://blog.oddbit.com/2013/11/22/a-unified-cli-for-op
 Note ini format supports name:value so quite a lot of overlap
 
 have pip install put man page in place
-
-Support spacing options for new items. I.E. allow to
-set=like_this rather than just set = like_this.
-This would have significance for shell like config formats
-when adding new parmeters. Maybe have --format=sh control this.

--- a/tests/nospace-in.ini
+++ b/tests/nospace-in.ini
@@ -1,0 +1,8 @@
+#comment = ignore
+p1 = 1
+p2 = 2 = 2
+p3 : 3 = 3
+p 4 = 4
+p5  = 5
+p6 : 6 : 6 a
+  multiline = ignore

--- a/tests/nospace-out.ini
+++ b/tests/nospace-out.ini
@@ -1,0 +1,9 @@
+#comment = ignore
+p1=1
+p2=2 = 2
+p3:3 = 3
+p 4=4
+p5=5
+p6:6 : 6 a
+  multiline = ignore
+new=val

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -113,6 +113,9 @@ for mode in '' '--inplace'; do
   # Maintain space separation
   crudini $mode --set example.ini section1 nospace val
   grep -q '^nospace=val' example.ini && ok || fail
+
+  crudini $mode --ini-options= --set example.ini section1 nospace val
+  grep -q '^nospace=val' example.ini && ok || fail
 done
 
 # value is optional
@@ -511,3 +514,8 @@ crudini --get test.ini DEFAULT param > /dev/null && ok || fail
 (>&- crudini --get test.ini section param value 2>/dev/null) && fail || ok
 (>&- crudini --set - section param value 2>/dev/null) && fail || ok
 (>&- crudini --set test.ini section param value) && ok || fail
+
+# Test --ini-options=nospace
+diff -u <(crudini --output=- --ini-options=nospace \
+          --set nospace-in.ini '' new val) \
+        nospace-out.ini && ok || fail


### PR DESCRIPTION
Add --ini-options=nospace option to enforce removal
of spacing around parameter delimiters.
I.e. use 'name=value' rather than 'name = value'.

Note we don't currently support enforcing spacing like 'name = value'
as that is generally not needed, as if a parser supports spaces
it generally supports lack of spaces.  Also we don't support only
adjusting spacing of specified parameters, as again if mixed spacing
is supported, there would be no need for this option.

* crudini.py: Add support for the new --ini-options command line option,
which is initially accepting the 'nospace' option, and can be extended
to support other ini format variants in future.
The 'nospace' implementation is in two parts, for existing and new
options. The reformatting of existing parameters is done in
CrudiniInputFilter.readline(), while formatting of new parameters
is supported by wrapping iniparse's OptionLine class in
CrudiniConfigParser(). Note the latter maps using a
space_around_delimiters parameter to ease possible future
use of the configparser interface rather than iniparse.
* EXAMPLES: Add examples for reformatting and updating with nospace.
* README: Auto updated from above.
* TODO: Remove associated todo item.
* tests/test.sh: Add new test.
* tests/nospace-in.ini: Support new test.
* tests/nospace-out.ini: Likewise.

Closes issue #33